### PR TITLE
Fix type resolutian failure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ impl Gravatar {
             let mut url = Url::parse(&base_url).ok().unwrap();
             url.set_query_from_pairs(
                 params.iter().map(
-                    |&(ref k, ref v)| (k.as_ref(), v.as_ref())
+                    |&(ref k, ref v)| (&*k, &*v)
                 )
             );
             url.serialize()


### PR DESCRIPTION
```
error: type annotations required: cannot resolve `collections::string::String : core::convert::AsRef<_>`
```

Not sure why this has started failing, but I get this error on `rustc 1.4.0 (8ab8581f6 2015-10-27)` and `rustc 1.7.0-nightly (7dce32e65 2016-01-20)`. I tried adding type annotations but it started complaining that `params` needed to live for `'static` with them, this seems to work fine.
