### PR TITLE
Remove incorrect double-encoding of `ImageUrl`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ keywords = [
 license = "BSD-3-Clause"
 
 [dependencies]
-md-5 = "0.8.0"
-url = "1.7.2"
+md-5 = "0.10.5"
+url = "2.4.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ extern crate md5;
 extern crate url;
 
 use md5::{Digest, Md5};
-use url::percent_encoding::{utf8_percent_encode, DEFAULT_ENCODE_SET};
 use url::Url;
 
 /// The default image to display if the user's email does not have a Gravatar.
@@ -185,9 +184,7 @@ impl Gravatar {
 
         if let Some(ref d) = self.default {
             let val = match d {
-                Default::ImageUrl(ref u) => {
-                    utf8_percent_encode(u.as_str(), DEFAULT_ENCODE_SET).to_string()
-                }
+                Default::ImageUrl(ref u) => u.to_string(),
                 Default::Http404 => "404".to_string(),
                 Default::MysteryMan => "mm".to_string(),
                 Default::Identicon => "identicon".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,10 +161,9 @@ impl Gravatar {
     /// Returns the image URL of the user's Gravatar with all specified parameters.
     pub fn image_url(self: &Self) -> Url {
         // Generate MD5 hash of email
-        let digest = Md5::new()
-            .chain(&self.email.trim().to_ascii_lowercase())
-            .result();
-        let hash = format!("{:x}", digest);
+        let mut hasher = Md5::new();
+        hasher.update(&self.email.trim().to_ascii_lowercase());
+        let hash = format!("{:x}", hasher.finalize());
 
         // Create base URL using the hash
         let mut url = Url::parse(&format!(

--- a/tests/gravatar.rs
+++ b/tests/gravatar.rs
@@ -48,11 +48,11 @@ fn test_default() {
 fn test_default_url() {
     let mut g = Gravatar::new("email@example.com");
     g.set_default(Some(Default::ImageUrl(
-        Url::parse("http://example.org/im age").unwrap(),
+        Url::parse("http://example.org/im age?").unwrap(),
     )));
     assert_eq!(
         g.image_url().as_str(),
-        "https://secure.gravatar.com/avatar/5658ffccee7f0ebfda2b226238b1eb6e?d=http%3A%2F%2Fexample.org%2Fim%2520age"
+        "https://secure.gravatar.com/avatar/5658ffccee7f0ebfda2b226238b1eb6e?d=http%3A%2F%2Fexample.org%2Fim%2520age%3F"
     )
 }
 


### PR DESCRIPTION
The `url::UrlQuery` API already takes care of encoding. This extra encoding step resulted in an incorrect double-encoding of `url?` to `d=url%253F` rather than the correct `d=url%3F`.